### PR TITLE
Qt fix and repacement for GetVersionEx

### DIFF
--- a/npackdg/src/dbrepository.cpp
+++ b/npackdg/src/dbrepository.cpp
@@ -31,7 +31,9 @@
 #include "downloader.h"
 
 // this is necessary in Qt 5.11 and earlier versions for the static build
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0) && QT_LINK_STATIC == 1
 Q_IMPORT_PLUGIN(QSQLiteDriverPlugin)
+#endif
 
 static bool packageVersionLessThan3(const PackageVersion* a,
         const PackageVersion* b)

--- a/npackdg/src/npackdg_plugin_import.cpp
+++ b/npackdg/src/npackdg_plugin_import.cpp
@@ -2,6 +2,7 @@
 #include <QtPlugin>
 
 // this is necessary in Qt 5.11 and earlier versions for the static build
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0) && QT_LINK_STATIC == 1
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 Q_IMPORT_PLUGIN(QICNSPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
@@ -12,3 +13,4 @@ Q_IMPORT_PLUGIN(QTgaPlugin)
 Q_IMPORT_PLUGIN(QTiffPlugin)
 Q_IMPORT_PLUGIN(QWbmpPlugin)
 Q_IMPORT_PLUGIN(QWebpPlugin)
+#endif

--- a/npackdg/src/wellknownprogramsthirdpartypm.cpp
+++ b/npackdg/src/wellknownprogramsthirdpartypm.cpp
@@ -170,7 +170,29 @@ void WellKnownProgramsThirdPartyPM::detectWindows(
 {
     OSVERSIONINFO osvi;
     osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-    GetVersionEx(&osvi);
+	osvi.dwMajorVersion = 6;
+	osvi.dwMinorVersion = 2;
+	osvi.dwBuildNumber = 0;
+	DWORD dwDummy = 0;
+	DWORD dwFVISize = GetFileVersionInfoSize(L"Kernel32.dll", &dwDummy);
+	LPBYTE lpVersionInfo = new BYTE[dwFVISize];
+	if (GetFileVersionInfo(L"Kernel32.dll", 0, dwFVISize, lpVersionInfo) == 0)
+		delete lpVersionInfo;
+	else
+	{
+		UINT uLen;
+		VS_FIXEDFILEINFO *lpFfi;
+		BOOL bVer = VerQueryValue(lpVersionInfo, L"\\", (LPVOID *)&lpFfi, &uLen);
+		if (!(!bVer || uLen == 0))
+		{
+			DWORD dwFileVersionMS = lpFfi->dwProductVersionMS;
+			DWORD dwFileVersionLS = lpFfi->dwProductVersionLS;
+			osvi.dwMajorVersion = HIWORD(dwFileVersionMS);
+			osvi.dwMinorVersion = LOWORD(dwFileVersionMS);
+			osvi.dwBuildNumber = HIWORD(dwFileVersionLS);
+		}
+		delete[] lpVersionInfo;
+	}
     Version v;
     v.setVersion(static_cast<int>(osvi.dwMajorVersion),
             static_cast<int>(osvi.dwMinorVersion),

--- a/npackdg/src/wpmutils.cpp
+++ b/npackdg/src/wpmutils.cpp
@@ -19,6 +19,7 @@
 #include <taskschd.h>
 #include <comdef.h>
 #include <sddl.h>
+#include <VersionHelpers.h>
 
 //#define CCH_RM_MAX_APP_NAME 255
 //#define CCH_RM_MAX_SVC_NAME 63
@@ -1873,12 +1874,8 @@ QList<HANDLE> WPMUtils::getProcessHandlesLockingDirectory(const QString& dir)
 {
     QList<HANDLE> r;
 
-    OSVERSIONINFO osvi;
-    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-    GetVersionEx(&osvi);
-
     // >= Windows Vista
-    if (osvi.dwMajorVersion >= 6) {
+    if (IsWindowsVistaOrGreater()) {
         typedef BOOL (WINAPI *LPFQUERYFULLPROCESSIMAGENAME)(
                 HANDLE, DWORD, LPTSTR, PDWORD);
 
@@ -2273,12 +2270,8 @@ QStringList WPMUtils::getProcessFiles()
 {
     QStringList r;
 
-    OSVERSIONINFO osvi;
-    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-    GetVersionEx(&osvi);
-
     // >= Windows Vista
-    if (osvi.dwMajorVersion >= 6) {
+    if (IsWindowsVistaOrGreater()) {
         typedef BOOL (WINAPI *LPFQUERYFULLPROCESSIMAGENAME)(
                 HANDLE, DWORD, LPTSTR, PDWORD);
 


### PR DESCRIPTION
Q_IMPORT_PLUGIN is necessary in Qt 5.11 and earlier versions for the static build. With other configurations, such as Qt 5.13 dynamic, the macros generate linker errors (LNK2019).

https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa

> [GetVersionEx may be altered or unavailable for releases after Windows 8.1. Instead, use the Version Helper functions] 
> 
> With the release of Windows 8.1, the behavior of the GetVersionEx API has changed in the value it will return for the operating system version. The value returned by the GetVersionEx function now depends on how the application is manifested.
> 
> Applications not manifested for Windows 8.1 or Windows 10 will return the Windows 8 OS version value (6.2). Once an application is manifested for a given operating system version, GetVersionEx will always return the version that the application is manifested for in future releases. To manifest your applications for Windows 8.1 or Windows 10, refer to Targeting your application for Windows.

This change could cause problems, so I replaced the function in d4316ec. In addition, the function may be removed in the future.