### PR TITLE
Add missing taskschd.lib to CMake

### DIFF
--- a/clu/CMakeLists.txt
+++ b/clu/CMakeLists.txt
@@ -155,7 +155,7 @@ if(${NPACKD_FORCE_STATIC})
     SET(CLU_LIBRARIES ${CLU_LIBRARIES} qtpcre2 zstd z)
 endif()
 
-SET(CLU_LIBRARIES ${CLU_LIBRARIES} userenv winmm ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32)
+SET(CLU_LIBRARIES ${CLU_LIBRARIES} userenv winmm ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32 taskschd)
 
 add_executable(clu
     ${CLU_SOURCES}

--- a/npackdcl/CMakeLists.txt
+++ b/npackdcl/CMakeLists.txt
@@ -143,7 +143,7 @@ if(${NPACKD_FORCE_STATIC})
     SET(NPACKDCL_LIBRARIES ${NPACKDCL_LIBRARIES} mingwex qtpcre2 icuin icuuc icudt icutu zstd z)
 endif()
 
-SET(NPACKDCL_LIBRARIES ${NPACKDCL_LIBRARIES} userenv winmm ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32)
+SET(NPACKDCL_LIBRARIES ${NPACKDCL_LIBRARIES} userenv winmm ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32 taskschd)
 
 target_link_libraries(npackdcl ${NPACKDCL_LIBRARIES})
 target_include_directories(npackdcl PRIVATE ${QUAZIP_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/../npackdg/src)

--- a/npackdcl/ftests/CMakeLists.txt
+++ b/npackdcl/ftests/CMakeLists.txt
@@ -133,7 +133,7 @@ if(${NPACKD_FORCE_STATIC})
     SET(FTESTS_LIBRARIES ${FTESTS_LIBRARIES} qtpcre2 icuin icuuc icudt icutu qtharfbuzz zstd z)
 endif()
 
-SET(FTESTS_LIBRARIES ${FTESTS_LIBRARIES} userenv winmm ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32)
+SET(FTESTS_LIBRARIES ${FTESTS_LIBRARIES} userenv winmm ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32 taskschd)
 
 add_executable(ftests
         ${FTESTS_SOURCES}

--- a/npackdcl/tests/CMakeLists.txt
+++ b/npackdcl/tests/CMakeLists.txt
@@ -134,7 +134,7 @@ if(${NPACKD_FORCE_STATIC})
     SET(TESTS_LIBRARIES ${TESTS_LIBRARIES} qtpcre2 icuin icuuc icudt icutu qtharfbuzz zstd z)
 endif()
 
-SET(TESTS_LIBRARIES ${TESTS_LIBRARIES} userenv winmm ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32)
+SET(TESTS_LIBRARIES ${TESTS_LIBRARIES} userenv winmm ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32 taskschd)
 
 add_executable(tests
     ${TESTS_SOURCES}

--- a/npackdg/CMakeLists.txt
+++ b/npackdg/CMakeLists.txt
@@ -212,19 +212,15 @@ qt5_add_translation(NPACKDG_TRANSLATIONS_QM ${NPACKDG_TRANSLATIONS})
 
 SET(NPACKDG_LIBRARIES ${QUAZIP_LIBRARIES} ${ZLIB_LIBRARIES})
 
-if(${NPACKD_FORCE_STATIC})
-    SET(NPACKDG_LIBRARIES ${NPACKDG_LIBRARIES} qsqlite qicns qico qjpeg qgif qtga qtiff qwbmp qwebp)
-endif()
-
-SET(NPACKDG_LIBRARIES ${NPACKDG_LIBRARIES} Qt5::WinExtras qwindows Qt5VulkanSupport qwindowsvistastyle Qt5::Widgets Qt5FontDatabaseSupport Qt5::Gui Qt5::Sql Qt5::Xml Qt5::Core)
+SET(NPACKDG_LIBRARIES ${NPACKDG_LIBRARIES} Qt5::WinExtras Qt5VulkanSupport Qt5::Widgets Qt5FontDatabaseSupport Qt5::Gui Qt5::Sql Qt5::Xml Qt5::Core)
 
 if(${NPACKD_FORCE_STATIC})
-    SET(NPACKDG_LIBRARIES ${NPACKDG_LIBRARIES} qsqlite qicns qico qjpeg qgif qtga qtiff qwbmp qwebp)
+    SET(NPACKDG_LIBRARIES ${NPACKDG_LIBRARIES} qsqlite qicns qico qjpeg qgif qtga qtiff qwbmp qwebp qwindows qwindowsvistastyle)
     SET(NPACKDG_LIBRARIES ${NPACKDG_LIBRARIES} mingwex Qt5ThemeSupport Qt5EventDispatcherSupport Qt5FontDatabaseSupport Qt5PlatformCompositorSupport Qt5WindowsUIAutomationSupport qdirect2d)
     SET(NPACKDG_LIBRARIES ${NPACKDG_LIBRARIES} jasper icuin icuuc icudt icutu qtpcre2 qtharfbuzz qtfreetype qtlibpng jpeg zstd z)
 endif()
 
-SET(NPACKDG_LIBRARIES ${NPACKDG_LIBRARIES} imm32 winmm glu32 mpr userenv wtsapi32 opengl32 ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32 UxTheme Dwmapi)
+SET(NPACKDG_LIBRARIES ${NPACKDG_LIBRARIES} imm32 winmm glu32 mpr userenv wtsapi32 opengl32 ole32 uuid wininet psapi version shlwapi msi netapi32 Ws2_32 UxTheme Dwmapi taskschd)
 
 target_link_libraries(npackdg ${NPACKDG_LIBRARIES})
 target_include_directories(npackdg PRIVATE ${QUAZIP_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})


### PR DESCRIPTION
```
1>wpmutils.obj : error LNK2001: Nicht aufgelöstes externes Symbol "IID_ITaskService".
1>wpmutils.obj : error LNK2001: Nicht aufgelöstes externes Symbol "IID_IDailyTrigger".
1>wpmutils.obj : error LNK2001: Nicht aufgelöstes externes Symbol "IID_IExecAction".
1>wpmutils.obj : error LNK2001: Nicht aufgelöstes externes Symbol "CLSID_TaskScheduler".
```
taskschd.lib is missing